### PR TITLE
Inline final auth to gen default value

### DIFF
--- a/epayment.v1.yml
+++ b/epayment.v1.yml
@@ -280,7 +280,15 @@ components:
         amount:
           $ref: '#/components/schemas/Amount'
         authorisationType:
-          $ref: '#/components/schemas/AuthorisationType'
+          title: AuthorisationType
+          type: string
+          enum:
+            - FINAL_AUTH
+          x-enum-varnames:
+            - FINAL_AUTH
+          example: FINAL_AUTH
+          default: FINAL_AUTH
+          description: Flags a card payment request for final authorisation.
         state:
           $ref: '#/components/schemas/State'
         directCapture:
@@ -617,7 +625,15 @@ components:
       type: object
       properties:
         authorisationType:
-          $ref: '#/components/schemas/AuthorisationType'
+          title: AuthorisationType
+          type: string
+          enum:
+            - FINAL_AUTH
+          x-enum-varnames:
+            - FINAL_AUTH
+          example: FINAL_AUTH
+          default: FINAL_AUTH
+          description: Flags a card payment request for final authorisation.
         modificationAmount:
           $ref: '#/components/schemas/Amount'
         modificationReference:
@@ -660,7 +676,15 @@ components:
         amount:
           $ref: '#/components/schemas/Amount'
         authorisationType:
-          $ref: '#/components/schemas/AuthorisationType'
+          title: AuthorisationType
+          type: string
+          enum:
+            - FINAL_AUTH
+          x-enum-varnames:
+            - FINAL_AUTH
+          example: FINAL_AUTH
+          default: FINAL_AUTH
+          description: Flags a card payment request for final authorisation.
         processedAt:
           type: string
           format: date-time
@@ -677,16 +701,6 @@ components:
         - paymentAction
         - amount
         - processedAt
-    AuthorisationType:
-      title: AuthorisationType
-      type: string
-      enum:
-        - FINAL_AUTH
-      x-enum-varnames:
-        - FINAL_AUTH
-      example: FINAL_AUTH
-      default: FINAL_AUTH
-      description: Flags a card payment request for final authorisation.
     Problem:
       title: Problem
       type: object


### PR DESCRIPTION
OpenAPI generator doesn't recognize default values set in reference for some reason. This causes a bug in ePayments API where omitting the AuthorizationType value causes a 500 error. Inlining the references is a workaround.
This is probably a bug in the generator.

https://stackoverflow.com/questions/68534849/open-api-spec-v2-0-default-value-of-a-field-of-type-enum
