### PR TITLE
Update payment reference property to have the same validation rules on all endpoints

### DIFF
--- a/docs/epayment.v1.yml
+++ b/docs/epayment.v1.yml
@@ -790,7 +790,7 @@ components:
       required: true
       schema:
         type: string
-        pattern: '^[a-zA-Z0-9-]{1,50}$'
+        pattern: '^[a-zA-Z0-9-]{8,50}$'
         minLength: 1
         maxLength: 50
       description: Given primary reference when creating the payment


### PR DESCRIPTION
Have the same validation on the payment reference property on the endpoint path parameter as it is has when it is created in POST /payment