### PR TITLE
Modify AirlineData to require all fields except for TicketNumber

### DIFF
--- a/docs/epayment.v1.yml
+++ b/docs/epayment.v1.yml
@@ -355,7 +355,7 @@ components:
         - paymentMethod
         - reference
         - returnUrl
-        - userFlow      
+        - userFlow
     AirlineData:
       title: AirlineData
       type: object

--- a/docs/epayment.v1.yml
+++ b/docs/epayment.v1.yml
@@ -355,10 +355,15 @@ components:
         - paymentMethod
         - reference
         - returnUrl
-        - userFlow
+        - userFlow      
     AirlineData:
       title: AirlineData
       type: object
+      required:
+        - agencyInvoiceNumber
+        - airlineCode
+        - airlineDesignatorCode
+        - passengerName      
       description: |-
         Airline related data
 


### PR DESCRIPTION
The current swaggerdef allowed for airline data to contain empty values in all fields. Added "required" fields to that structure, so that only ticketnumber is allowed to be missing. 