### PR TITLE
Replace state "AUTHORISED" with "AUTHORIZED"

### DIFF
--- a/docs/api/Getting-Started.md
+++ b/docs/api/Getting-Started.md
@@ -161,7 +161,7 @@ curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE \
 -X GET
 ```
 
-To verify if a payment has been authorised by the user check if the `state` property is marked `AUTHORISED`. If the user has instead chosen to reject the payment or the user has instead chosen to click `cancel` on the landing page (card) the `state` property is marked `ABORTED`. If the user did not act within the payment expiration time then the `state` property is marked `EXPIRED`.
+To verify if a payment has been authorised by the user check if the `state` property is marked `AUTHORIZED`. If the user has instead chosen to reject the payment or the user has instead chosen to click `cancel` on the landing page (card) the `state` property is marked `ABORTED`. If the user did not act within the payment expiration time then the `state` property is marked `EXPIRED`.
 
 The payment event log can be fetched as such:
 


### PR DESCRIPTION
Docs does not appear to correctly reflect the current api response, as "AUTHORIZED" is returned rather than the described "AUTHORISED".