### PR TITLE
Mark notification webhooks as draft (additional places)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ END_METADATA -->
 <!-- START_COMMENT -->
 
 ℹ️ Please use the new documentation:
-[Vipps Technical Documentation](https://vippsas.github.io/vipps-developer-docs/).
+[Vipps Technical Documentation](https://vippsas.github.io/vipps-developer-docs/docs/APIs/epayment-api).
 
 <!-- END_COMMENT -->
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,3 @@ pages for information about API keys, product activation, contact information, c
 
 * [API guide](./api-guide/getting-started.md): Developer guide for Vipps ePayment API.
 * [API Reference](https://vippsas.github.io/vipps-developer-docs/api/epayment): ePayment API Reference Specifications.
-
-## Questions?
-
-We're always happy to help with code or other questions you might have!
-Please create an [issue](https://github.com/vippsas/vipps-epayment-api/issues),
-a [pull request](https://github.com/vippsas/vipps-epayment-api/pulls),
-or [contact us](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/contact).
-
-Sign up for our [Technical newsletter for developers](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/newsletters).

--- a/api-guide/README.md
+++ b/api-guide/README.md
@@ -2,7 +2,7 @@
 ---
 title: Introduction
 sidebar_label: API guide
-sidebar_position: 10
+sidebar_position: 30
 pagination_prev: Null
 pagination_next: Null
 ---

--- a/api-guide/README.md
+++ b/api-guide/README.md
@@ -12,7 +12,9 @@ END_METADATA -->
 
 - [Start with Getting Started](getting-started.md)
 - [Capture the payment](modifications/capture.md)
-- [How to setup Notification Webhooks](how-to-setup-notification-webhooks.md)
 - [Payment modification, how to use cancel, capture and refund?](modifications/README.md)
 - [Using Vipps Merchant Payments in a shopper present context](features/customer-present-payments.md)
 - [Profile sharing, requesting the users personal information](features/profile-sharing.md)
+<!-- 
+- [How to setup Notification Webhooks](how-to-setup-notification-webhooks.md)
+-->

--- a/api-guide/README.md
+++ b/api-guide/README.md
@@ -15,6 +15,7 @@ END_METADATA -->
 - [Payment modification, how to use cancel, capture and refund?](modifications/README.md)
 - [Using Vipps Merchant Payments in a shopper present context](features/customer-present-payments.md)
 - [Profile sharing, requesting the users personal information](features/profile-sharing.md)
-<!-- 
-- [How to setup Notification Webhooks](how-to-setup-notification-webhooks.md)
--->
+
+<!-- START_COMMENT -->
+<!-- [How to setup Notification Webhooks](how-to-setup-notification-webhooks.md) -->
+<!-- END_COMMENT -->

--- a/api-guide/_tmp_vipps-epayment-api.md
+++ b/api-guide/_tmp_vipps-epayment-api.md
@@ -120,7 +120,7 @@ the detailed flow and [Payment states](#payment-states) for the corresponding
 states.
 
 The flow of settlements and how to retrieve them are described in
-[Settlements](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/settlements/).
+[Settlements](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/settlements).
 
 ## Quick start
 

--- a/api-guide/getting-started.md
+++ b/api-guide/getting-started.md
@@ -21,10 +21,12 @@ This document covers the quick steps for getting started with the Vipps Merchant
 You must have already signed up as a organisation with Vipps and have your test credentials from the merchant portal, as described in the
 [Vipps Getting Started guide](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/vipps-getting-started).
 
+<!-- START_COMMENT -->
 <!--
 Once your merchant account is setup for Merchant Payments, you should look at available configuration options, such as
 [Notifications Webhooks](how-to-setup-notification-webhooks.md).
 -->
+<!-- END_COMMENT -->
 
 ## Your first Vipps Payment
 
@@ -102,10 +104,13 @@ To receive the result of the users action you may poll the status of the payment
 [Get Payment][get-payment-endpoint] and
 [Get Payment Event Log][get-payment-event-log-endpoint] endpoints.
 
+<!-- START_COMMENT -->
 <!--
 Alternatively, receive status updates over our [Notification Webhooks](how-to-setup-notification-webhooks.md) service
 
 -->
+<!-- END_COMMENT -->
+
 ### Polling
 
 A request to the [Get Payment][get-payment-endpoint] URL will provide the current status of the payment and an aggregate of the captured and refunded amounts.
@@ -167,7 +172,7 @@ In the case the payment has been completed this will yield an array of events li
   }
 ]
 ```
-
+<!-- START_COMMENT -->
 <!--
 ### Notification Events
 
@@ -212,6 +217,7 @@ If the user had rejected the payment, the event would look like
 }
 ```
 -->
+<!-- END_COMMENT -->
 
 ## Next Steps
 
@@ -222,7 +228,10 @@ read further to see the full range of possibilities within the Vipps Merchant Pa
 - [Payment modification, how to use cancel, capture and refund?](modifications/README.md)
 - [Using Vipps Merchant Payments in a shopper present context](features/customer-present-payments.md)
 - [Profile sharing, requesting the users personal information](features/profile-sharing.md)
+
+<!-- START_COMMENT -->
 <!-- [How to setup Notification Webhooks](how-to-setup-notification-webhooks.md) -->
+<!-- END_COMMENT -->
 
 [create-payment-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/epayment#tag/CreatePayments/operation/createPayment
 [get-payment-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/epayment#tag/QueryPayments/operation/getPayment

--- a/api-guide/how-to-setup-notification-webhooks.md
+++ b/api-guide/how-to-setup-notification-webhooks.md
@@ -4,6 +4,7 @@ title: Notification Webhooks
 sidebar_position: 110
 pagination_next: null
 pagination_prev: null
+draft: true
 ---
 END_METADATA -->
 

--- a/vipps-epayment-api-checklist.md
+++ b/vipps-epayment-api-checklist.md
@@ -88,7 +88,7 @@ API version: 1.0.
 
 ## Flow to go live for direct integrations for partners
 
-See: [Vipps partners](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/).
+See: [Vipps partners](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner).
 
 
 [portal-url]: https://portal.vipps.no

--- a/vipps-epayment-api-checklist.md
+++ b/vipps-epayment-api-checklist.md
@@ -1,7 +1,7 @@
 <!-- START_METADATA
 ---
 title: Checklist
-sidebar_position: 10
+sidebar_position: 40
 ---
 END_METADATA -->
 

--- a/vipps-epayment-api-faq.md
+++ b/vipps-epayment-api-faq.md
@@ -2,6 +2,7 @@
 ---
 title: FAQs
 draft: true
+sidebar_position: 50
 ---
 END_METADATA -->
 

--- a/vipps-epayment-api-howitworks.md
+++ b/vipps-epayment-api-howitworks.md
@@ -2,5 +2,6 @@
 ---
 title: How it works
 draft: true
+sidebar_position: 10
 ---
 END_METADATA -->


### PR DESCRIPTION
We need to hide the commented-out links or docusaurus complains