### PR TITLE
Suggested improvements before prime-time

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -8,7 +8,7 @@ END_METADATA -->
 
 # Payment operations
 
-ePayment API exposes 6 payment operations:
+The ePayment API exposes six payment operations:
 
 * [Create a payment](create.md)
 * [Capture a payment](capture.md)
@@ -16,3 +16,5 @@ ePayment API exposes 6 payment operations:
 * [Refund a payment](refund.md)
 * [Get a payment](get_info.md)
 * [Get payment event log](get_event_log.md)
+
+See: [Payment states and modifications](../payment_states).

--- a/operations/cancel.md
+++ b/operations/cancel.md
@@ -23,7 +23,7 @@ the user's bank statement and Vipps payment overview with their expectations fro
 a merchant.
 
 A payment can be cancelled via the API or
-[porta.vipps.no](https://portal.vipps.no)
+[portal.vipps.no](https://portal.vipps.no)
 at any point until the
 payment is fully captured. A cancellation will release any remaining authorized
 funds on the customers bank account.

--- a/operations/cancel.md
+++ b/operations/cancel.md
@@ -15,173 +15,179 @@ See
 [Common API topics - Cancellations](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/cancel)
 for a general introduction to cancellations.
 
-If you no longer wish to initiate settlement of the remaining funds on a payment then you should [Cancel][cancel-payment-endpoint] the payment. Cancelling a payment provides a good user experience and synchronizes the users bank statement and Vipps payment overview with their expectations from a merchant.
+If you no longer wish to initiate settlement of the remaining funds on a payment
+then you should cancel the payment:
+[`POST:/payments/{reference}/cancel`][cancel-payment-endpoint].
+Cancelling a payment provides a good user experience and synchronizes
+the user's bank statement and Vipps payment overview with their expectations from
+a merchant.
 
-A payment can be cancelled via the api or merchant portal at any point until the payment is fully captured. A cancellation will release any remaining authorized funds on the customers bank account.
+A payment can be cancelled via the API or
+[porta.vipps.no](https://portal.vipps.no)
+at any point until the
+payment is fully captured. A cancellation will release any remaining authorized
+funds on the customers bank account.
 
 ## Cancel via the API
 
-The payment can be cancelled through the [Cancel Payment Endpoint][cancel-payment-endpoint].
-
-An example cancel would look like:
-
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE/cancel \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Content-Type: application/json" \
--H "Idempotency-Key: UNIQUE-ID" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X POST
-```
-
+The payment can be cancelled with
+[`POST:/payments/{reference}/cancel`][cancel-payment-endpoint].
 
 ## Cancel before Authorization
 If the payment has not yet reached the `AUTHORIZED` state a cancellation by the merchant via the api will result in `TERMINATED` state of the payment.
+
 An example response for a cancel request pre-authorization looks like this
 ```json
 {
-    "amount": {
-        "currency": "NOK",
-        "value": 1000
-    },
-    "state": "TERMINATED",
-    "aggregate": {
-        "authorizedAmount": {
-            "currency": "NOK",
-            "value": 0
-        },
-        "cancelledAmount": {
-            "currency": "NOK",
-            "value": 1000
-        },
-        "capturedAmount": {
-            "currency": "NOK",
-            "value": 0
-        },
-        "refundedAmount": {
-            "currency": "NOK",
-            "value": 0
-        }
-    },
-    "pspReference": "70b6ebe0-b400-4652-a3ea-70645e025035",
-    "reference": "UNIQUE-PAYMENT-REFERENCE"
+   "amount":{
+      "currency":"NOK",
+      "value":1000
+   },
+   "state":"TERMINATED",
+   "aggregate":{
+      "authorizedAmount":{
+         "currency":"NOK",
+         "value":0
+      },
+      "cancelledAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "capturedAmount":{
+         "currency":"NOK",
+         "value":0
+      },
+      "refundedAmount":{
+         "currency":"NOK",
+         "value":0
+      }
+   },
+   "pspReference":"70b6ebe0-b400-4652-a3ea-70645e025035",
+   "reference":"UNIQUE-PAYMENT-REFERENCE"
 }
 ```
 
-After the cancel is complete, a notification will be sent if a [webhook](../features/webhooks.md) is registered for the event `epayments.payment.terminated.v1`.
+After the cancel is complete, a notification will be sent if a
+[webhook](../features/webhooks.md) is registered for the event
+`epayments.payment.terminated.v1`.
 
 ## Cancel after Authorization
-If the payment has reached the `AUTHORIZED` state a cancellation by the merchant via the api will **not** change the state of the payment, it will remain `AUTHORIZED`.
-However, the reserved amount from the customer will be released, and the `aggregate` object will reflect this with the `cancelledAmount` property.
-An example response for a cancel request Post-authorization looks like this:
+
+If the payment has reached the `AUTHORIZED` state a cancellation by the merchant
+via the API will **not** change the state of the payment, it will remain `AUTHORIZED`.
+However, the reserved amount from the customer will be released, and the `aggregate`
+object will reflect this with the `cancelledAmount` property.
+
+An example response for a
+[`POST:/payments/{reference}/cancel`][cancel-payment-endpoint]
+request post-authorization looks like this:
+
 ```json
 {
-    "amount": {
-        "currency": "NOK",
-        "value": 1000
-    },
-    "state": "AUTHORIZED",
-    "aggregate": {
-        "authorizedAmount": {
-            "currency": "NOK",
-            "value": 1000
-        },
-        "cancelledAmount": {
-            "currency": "NOK",
-            "value": 1000
-        },
-        "capturedAmount": {
-            "currency": "NOK",
-            "value": 0
-        },
-        "refundedAmount": {
-            "currency": "NOK",
-            "value": 0
-        }
-    },
-    "pspReference": "37c34d8c-2649-448e-864b-060d5d93e4c4",
-    "reference": "UNIQUE-PAYMENT-REFERENCE"
+   "amount":{
+      "currency":"NOK",
+      "value":1000
+   },
+   "state":"AUTHORIZED",
+   "aggregate":{
+      "authorizedAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "cancelledAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "capturedAmount":{
+         "currency":"NOK",
+         "value":0
+      },
+      "refundedAmount":{
+         "currency":"NOK",
+         "value":0
+      }
+   },
+   "pspReference":"37c34d8c-2649-448e-864b-060d5d93e4c4",
+   "reference":"UNIQUE-PAYMENT-REFERENCE"
 }
 ```
 
-Even though the state of a payment doesn't change, a notification will be sent after the cancellation is processed, if a [webhook](../features/webhooks.md) is registered for the event `epayments.payment.cancelled.v1`.
+Even though the state of a payment doesn't change, a notification will be sent
+after the cancellation is processed, if a
+[webhook](../features/webhooks.md) is registered for the event
+`epayments.payment.cancelled.v1`.
 
 :::info
-It is not possible to cancel a payment while a user is actively authorizing the payment. Eg: The payment is under processing with the payment scheme, or the user is in a 3DSecure session.
+It is not possible to cancel a payment while a user is actively authorizing the
+payment. Eg: The payment is under processing with the payment scheme, or the
+user is in a 3 D Secure session.
 :::
-
-
-
 
 ## Cancel after a partial capture
 
-If you have captured a partial amount of the authorized amount and will not capture the remaining amount you should release this. The cancel endpoint will do this for you when called.
+If you have captured a partial amount of the authorized amount and will not
+capture the remaining amount you should release this. The cancel endpoint will
+do this for you when called.
 
-For example we wish to release the remaining funds of a payment with the following aggregate state:
+For example we wish to release the remaining funds of a payment with the
+following aggregate state:
 
 ```json
 {
-  "aggregate": {
-    "authorizedAmount": {
-      "currency": "NOK",
-      "value": 1000
-    },
-    "cancelledAmount": {
-      "currency": "NOK",
-      "value": 0
-    },
-    "capturedAmount": {
-      "currency": "NOK",
-      "value": 250
-    },
-    "refundedAmount": {
-      "currency": "NOK",
-      "value": 0
-    }
-  }
+   "aggregate":{
+      "authorizedAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "cancelledAmount":{
+         "currency":"NOK",
+         "value":0
+      },
+      "capturedAmount":{
+         "currency":"NOK",
+         "value":250
+      },
+      "refundedAmount":{
+         "currency":"NOK",
+         "value":0
+      }
+   }
 }
 ```
 
-We would then call [Cancel][cancel-payment-endpoint] as normal
+We would then call
+[`POST:/payments/{reference}/cancel`][cancel-payment-endpoint]
+as normal.
 
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE/cancel \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Content-Type: application/json" \
--H "Idempotency-Key: UNIQUE-ID" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X POST
-```
-
-The aggregate would then be updated to reflect the modification and the funds release in the users bank account
+The `aggregate` would then be updated to reflect the modification and the funds
+release in the users bank account
 
 ```json
 {
-  "aggregate": {
-    "authorizedAmount": {
-      "currency": "NOK",
-      "value": 1000
-    },
-    "cancelledAmount": {
-      "currency": "NOK",
-      "value": 750
-    },
-    "capturedAmount": {
-      "currency": "NOK",
-      "value": 250
-    },
-    "refundedAmount": {
-      "currency": "NOK",
-      "value": 0
-    }
-  }
+   "aggregate":{
+      "authorizedAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "cancelledAmount":{
+         "currency":"NOK",
+         "value":750
+      },
+      "capturedAmount":{
+         "currency":"NOK",
+         "value":250
+      },
+      "refundedAmount":{
+         "currency":"NOK",
+         "value":0
+      }
+   }
 }
 ```
 
 :::note
-Cancelling a payment will always cancel the entire remaining not-captured amount, this is not reversible.
+Cancelling a payment will always cancel the entire remaining not-captured amount,
+this is irreversible.
 :::
 
 [cancel-payment-endpoint]: https://developer.vippsmobilepay.com/api/epayment#tag/AdjustPayments/operation/cancelPayment

--- a/operations/cancel.md
+++ b/operations/cancel.md
@@ -122,7 +122,7 @@ after the cancellation is processed, if a
 :::info
 It is not possible to cancel a payment while a user is actively authorizing the
 payment. Eg: The payment is under processing with the payment scheme, or the
-user is in a 3 D Secure session.
+user is in a 3-D Secure session.
 :::
 
 ## Cancel after a partial capture

--- a/operations/cancel.md
+++ b/operations/cancel.md
@@ -34,7 +34,9 @@ The payment can be cancelled with
 [`POST:/payments/{reference}/cancel`][cancel-payment-endpoint].
 
 ## Cancel before Authorization
-If the payment has not yet reached the `AUTHORIZED` state a cancellation by the merchant via the api will result in `TERMINATED` state of the payment.
+
+If the payment has not yet reached the `AUTHORIZED` state a cancellation by the
+merchant via the API will result in `TERMINATED` state of the payment.
 
 An example response for a cancel request pre-authorization looks like this
 ```json

--- a/operations/capture.md
+++ b/operations/capture.md
@@ -9,36 +9,33 @@ END_METADATA -->
 
 # Capture a payment
 
-See 
+See
 [Common API topics - Reserve and Capture](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/reserve-and-capture)
 for a general introduction to reservations and captures.
 
-A capture can be made in full, or partially if desired. The capture amount must be defined in capture API request.
+A capture can be made in full, or partially if desired. The capture amount must
+be defined in capture API request.
 
-Captured funds will be settled to the merchants settlement account after two business days. See [Settlement Information](https://developer.vippsmobilepay.com/docs/vipps-developers/settlements) for more details.
-
+Captured funds will be settled to the merchants settlement account after two
+business days. See
+[Settlement Information](https://developer.vippsmobilepay.com/docs/vipps-developers/settlements)
+for more details.
 
 ## Capture via the API
 
 Once the goods or services are delivered or on their way to the customer it is time to capture the payment.
-This can be done through the [Capture Payment Endpoint][capture-payment-endpoint].
+This can be done through the
+[`POST:/payments/{reference}/capture`][capture-payment-endpoint].
 
-An example capture would look like:
+An example of a capture request body:
 
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE/capture \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Content-Type: application/json" \
--H "Idempotency-Key: UNIQUE-ID" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X POST \
--d '{
-  "modificationAmount": {
-    "currency": "NOK",
-    "value": 1000
-  }
-}'
+```json
+{
+   "modificationAmount":{
+      "currency":"NOK",
+      "value":1000
+   }
+}
 ```
 
 In the response,  the `aggregate` object will be updated to reflect the capture, for example:
@@ -46,24 +43,24 @@ In the response,  the `aggregate` object will be updated to reflect the capture,
 
 ```json
 {
-  "aggregate": {
-    "authorizedAmount": {
-      "currency": "NOK",
-      "value": 1000
-    },
-    "cancelledAmount": {
-      "currency": "NOK",
-      "value": 0
-    },
-    "capturedAmount": {
-      "currency": "NOK",
-      "value": 1000
-    },
-    "refundedAmount": {
-      "currency": "NOK",
-      "value": 0
-    }
-  }
+   "aggregate":{
+      "authorizedAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "cancelledAmount":{
+         "currency":"NOK",
+         "value":0
+      },
+      "capturedAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "refundedAmount":{
+         "currency":"NOK",
+         "value":0
+      }
+   }
 }
 ```
 
@@ -75,49 +72,43 @@ If you do not wish to capture the entire amount a smaller amount than authorized
 
 The `Idempotency-Key` header is there to help you ensure at most once operation where needed.
 
-An example partial capture would look like:
-
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE/capture \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Content-Type: application/json" \
--H "Idempotency-Key: UNIQUE-ID" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X POST \
--d '{
-  "modificationAmount": {
-    "currency": "NOK",
-    "value": 250
-  }
-}'
-```
-
-Once capture is completed the `aggregate` object will be updated to reflect this, for example:
+An example of a partial capture request body:
 
 ```json
 {
-  "aggregate": {
-    "authorizedAmount": {
-      "currency": "NOK",
-      "value": 1000
-    },
-    "cancelledAmount": {
-      "currency": "NOK",
-      "value": 0
-    },
-    "capturedAmount": {
-      "currency": "NOK",
-      "value": 250
-    },
-    "refundedAmount": {
-      "currency": "NOK",
-      "value": 0
-    }
-  }
+   "modificationAmount":{
+      "currency":"NOK",
+      "value":250
+   }
 }
 ```
 
-If you are not going to capture the rest of the authorized amount you should [cancel](cancel.md#cancel-after-a-partial-capture) the remaining amount.
+Once capture is completed the `aggregate` will be updated to reflect this, for example:
+
+```json
+{
+   "aggregate":{
+      "authorizedAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "cancelledAmount":{
+         "currency":"NOK",
+         "value":0
+      },
+      "capturedAmount":{
+         "currency":"NOK",
+         "value":250
+      },
+      "refundedAmount":{
+         "currency":"NOK",
+         "value":0
+      }
+   }
+}
+```
+
+If you are not going to capture the rest of the authorized amount you should
+[cancel](cancel.md#cancel-after-a-partial-capture) the remaining amount.
 
 [capture-payment-endpoint]: https://developer.vippsmobilepay.com/api/epayment#tag/AdjustPayments/operation/capturePayment

--- a/operations/create.md
+++ b/operations/create.md
@@ -12,7 +12,7 @@ END_METADATA -->
 # Create payment
 
 The first step in the payment flow is creating a payment by calling
-[CreatePayment](https://developer.vippsmobilepay.com/api/epayment#tag/CreatePayments)
+[`POST:/payments`](https://developer.vippsmobilepay.com/api/epayment#tag/CreatePayments)
 endpoint. This endpoint supports card and wallet as payment methods and different user flows for each.
 
 ```mermaid
@@ -40,6 +40,7 @@ and how thew user experience will be.
 | `WEB_REDIRECT` | The normal flow for browser-based payment flows. |
 | `NATIVE_REDIRECT` | For automatic app-switch between the merchant's native app and the Vipps app. |
 | `PUSH_MESSAGE` | For payments initiated on a different device than the user's phone. Similar to [`skipLandingPage`](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/vipps-landing-page#skip-landing-page) in the [eCom API](https://developer.vippsmobilepay.com/docs/APIs/ecom-api)  |
+| `QR`| Returns a QR code that can be scanned to complete the payment. |
 
 ### WEB_REDIRECT
 

--- a/operations/create.md
+++ b/operations/create.md
@@ -11,7 +11,9 @@ END_METADATA -->
 
 # Create payment
 
-The first step in the payment flow is creating a payment by calling [CreatePayment](https://developer.vippsmobilepay.com/api/epayment#tag/CreatePayments) endpoint. This endpoint supports card and wallet as payment methods and different user flows for each.
+The first step in the payment flow is creating a payment by calling
+[CreatePayment](https://developer.vippsmobilepay.com/api/epayment#tag/CreatePayments)
+endpoint. This endpoint supports card and wallet as payment methods and different user flows for each.
 
 ```mermaid
 flowchart TD
@@ -24,31 +26,50 @@ flowchart TD
     Card --> CARD_WEB_REDIRECT[fa:fa-desktop userFlow: WEB_REDIRECT]
 ```
 
-`paymentMethod.type` in the request determines the type of payment. Allowed values are `CARD` and `WALLET`. Please note that card payment is not available in our test environment, but works in production.
+`paymentMethod.type` in the request determines the type of payment. Allowed
+values are `CARD` and `WALLET`.
+
+**Please note:** Card payment (`CARD`) is not available in test environment.
 
 ## User flow alternatives
 
+The `userFlow` parameter specifies how the API should handle the payment,
+and how thew user experience will be.
+
+| `userFlow` | Description |
+| `WEB_REDIRECT` | The normal flow for browser-based payment flows. |
+| `NATIVE_REDIRECT` | For automatic app-switch between the merchant's native app and the Vipps app. |
+| `PUSH_MESSAGE` | For payments initiated on a different device than the user's phone. Similar to [`skipLandingPage`](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/vipps-landing-page#skip-landing-page) in the [eCom API](https://developer.vippsmobilepay.com/docs/APIs/ecom-api)  |
+
 ### WEB_REDIRECT
 
-Default flow for:
+The default flow for:
 
-- wallet payments
-    - Opening the Vipps Landing Page on desktop, and automatic redirect to Vipps on mobile devices. More information at [Vipps landing page](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/vipps-landing-page)
-- card payments
-    - Opening the Vipps card entry page on both desktop/mobile. More information at [Card payments](https://developer.vippsmobilepay.com/docs/APIs/checkout-api/vipps-checkout-api-faq#card-payments)
+- Wallet payments
+    - Opens the
+    [Vipps landing page](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/vipps-landing-page)
+    on desktop, and automatic redirect to Vipps on mobile devices.
+- Card payments
+    - Opens the Vipps card entry page on both desktop and mobile. More information at
+    [Card payments](https://developer.vippsmobilepay.com/docs/APIs/checkout-api/vipps-checkout-api-faq#card-payments).
 
 
 ### NATIVE_REDIRECT
 
-Applicable only for Wallet payments.
-The given `redirectUrl` will automatically open the Vipps app on mobile devices.
-
+Applicable only for `WALLET` payments.
+The given `redirectUrl` will automatically open the Vipps app on mobile devices (app-switch).
 
 ### PUSH_MESSAGE
 
-Applicable only for Wallet payments. This will skip the Vipps landing page and is only allowed if user is not starting the payment from own device (e.g., from a Point Of Sale device, automates and similar).
-If userFlow is `PUSH_MESSAGE`, a valid value for `$.customer.phoneNumber` is required.
+Applicable only for `WALLET` payments. This will skip the
+[Vipps landing page](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/vipps-landing-page)
+and is only allowed if user is not starting the payment from own device
+(e.g., from a Point Of Sale device, vending machines and similar).
+
+If `userFlow` is `PUSH_MESSAGE`, a valid value for `customer.phoneNumber` is required.
 
 ### QR
 
-Applicable only for Wallet payments. For customer facing screens where payment can be initiated with [Vipps One Time Payment QR](https://developer.vippsmobilepay.com/docs/APIs/qr-api/vipps-qr-one-time-payment-api-howitworks).
+Applicable only for `WALLET` payments. For customer-facing screens where payment
+can be initiated with
+[Vipps One Time Payment QR](https://developer.vippsmobilepay.com/docs/APIs/qr-api/vipps-qr-one-time-payment-api-howitworks).

--- a/operations/get-event-log.md
+++ b/operations/get-event-log.md
@@ -8,18 +8,9 @@ description: Get payment events with the ePayment API.
 END_METADATA -->
 
 # Get payment event log
-A [Get payment event log][get-payment-event-log-endpoint] request will return a list of all events for a given payment.
 
-An example request would look like:
-
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE/events \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X GET \
-'
-```
+A [`GET:/payments/{reference}/events`][get-payment-event-log-endpoint]
+request will return a list of all events for a given payment.
 
 An example response would look like this:
 ```json
@@ -73,6 +64,5 @@ An example response would look like this:
     }
 ]
 ```
-
 
 [get-payment-event-log-endpoint]: https://developer.vippsmobilepay.com/api/epayment#tag/QueryPayments/operation/getPaymentEventLog

--- a/operations/get.md
+++ b/operations/get.md
@@ -9,18 +9,8 @@ END_METADATA -->
 
 # Get payment
 
-A [Get payment][get-payment-endpoint] request will return a point in time snapshot of a given payment.
-
-An example request would look like:
-
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X GET \
-'
-```
+A [`GET:/payments/{reference}`][get-payment-endpoint]
+request will return a point in time snapshot of a given payment.
 
 An example response would look like this:
 ```json
@@ -57,10 +47,15 @@ An example response would look like this:
 }
 ```
 
-In the case where the merchant requested `scopes` in the [Create payment][create-payment-endpoint] request, the `.profile` object will contain a `sub` identifying the customer, after the customer has authorized the payment, for example
+In the case where the merchant requested `scopes` in the
+[Create payment][create-payment-endpoint]
+request, the `profile` object will contain a `sub` identifying the customer,
+after the customer has authorized the payment.
+
+For example (truncated):
+
 ```json
 {
-  ..., 
   "state": "AUTHORIZED",
   "profile" : {
     "sub": "c06c4afe-d9e1-4c5d-939a-177d752a0944"
@@ -68,6 +63,9 @@ In the case where the merchant requested `scopes` in the [Create payment][create
 }
 ```
 
+The `sub` can then be used to retrieve the user's info with the
+[Userinfo API](https://developer.vippsmobilepay.com/docs/APIs/userinfo-api):
+[`GET:i/userinfo/{sub}`](https://developer.vippsmobilepay.com/api/userinfo#operation/getUserinfo).
 
 [get-payment-endpoint]: https://developer.vippsmobilepay.com/api/epayment#tag/QueryPayments/operation/getPayment
 [create-payment-endpoint]: https://developer.vippsmobilepay.com/api/epayment#tag/CreatePayments/operation/createPayment

--- a/operations/get.md
+++ b/operations/get.md
@@ -65,7 +65,7 @@ For example (truncated):
 
 The `sub` can then be used to retrieve the user's info with the
 [Userinfo API](https://developer.vippsmobilepay.com/docs/APIs/userinfo-api):
-[`GET:i/userinfo/{sub}`](https://developer.vippsmobilepay.com/api/userinfo#operation/getUserinfo).
+[`GET:/userinfo/{sub}`](https://developer.vippsmobilepay.com/api/userinfo#operation/getUserinfo).
 
 [get-payment-endpoint]: https://developer.vippsmobilepay.com/api/epayment#tag/QueryPayments/operation/getPayment
 [create-payment-endpoint]: https://developer.vippsmobilepay.com/api/epayment#tag/CreatePayments/operation/createPayment

--- a/operations/get_event_log.md
+++ b/operations/get_event_log.md
@@ -7,69 +7,59 @@ END_METADATA -->
 
 # Get payment event log
 
-A [Get payment event log][get-payment-endpoint] request will return a list of all events for a given payment.
-
-An example request would look like:
-
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE/events \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X GET \
-'
-```
+A [`GET:/payments/{reference}/events`][get-payment-endpoint]
+request will return a list of all events for a given payment.
 
 An example response would look like this:
 ```json
 [
-    {
-        "reference": "UNIQUE-PAYMENT-REFERENCE",
-        "pspReference": "83b3fdb0-9547-4ec5-bdb7-5600ce70e792",
-        "name": "CREATED",
-        "amount": {
-            "currency": "NOK",
-            "value": 1000
-        },
-        "timestamp": "2023-03-27T10:51:44.5333258Z",
-        "idempotencyKey": "19986263-dedf-4b8e-a424-8d042eee4013",
-        "success": true
-    },
-    {
-        "reference": "UNIQUE-PAYMENT-REFERENCE",
-        "pspReference": "1304787731",
-        "name": "AUTHORIZED",
-        "amount": {
-            "currency": "NOK",
-            "value": 1000
-        },
-        "timestamp": "2023-03-27T10:51:59.378Z",
-        "idempotencyKey": "19986263-dedf-4b8e-a424-8d042eee4013",
-        "success": true
-    },
-    {
-        "reference": "UNIQUE-PAYMENT-REFERENCE",
-        "pspReference": "2018200034",
-        "name": "CAPTURED",
-        "amount": {
-            "currency": "NOK",
-            "value": 250
-        },
-        "timestamp": "2023-03-27T10:52:07.748Z",
-        "idempotencyKey": "19986263-dedf-4b8e-a424-8d042eee4013",
-        "success": true
-    },
-    {
-        "reference": "UNIQUE-PAYMENT-REFERENCE",
-        "pspReference": "2019200034",
-        "name": "CANCELLED",
-        "amount": {
-            "currency": "NOK",
-            "value": 750
-        },
-        "timestamp": "2023-03-27T10:52:15.616Z",
-        "success": true
-    }
+   {
+      "reference":"UNIQUE-PAYMENT-REFERENCE",
+      "pspReference":"83b3fdb0-9547-4ec5-bdb7-5600ce70e792",
+      "name":"CREATED",
+      "amount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "timestamp":"2023-03-27T10:51:44.5333258Z",
+      "idempotencyKey":"19986263-dedf-4b8e-a424-8d042eee4013",
+      "success":true
+   },
+   {
+      "reference":"UNIQUE-PAYMENT-REFERENCE",
+      "pspReference":"1304787731",
+      "name":"AUTHORIZED",
+      "amount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "timestamp":"2023-03-27T10:51:59.378Z",
+      "idempotencyKey":"19986263-dedf-4b8e-a424-8d042eee4013",
+      "success":true
+   },
+   {
+      "reference":"UNIQUE-PAYMENT-REFERENCE",
+      "pspReference":"2018200034",
+      "name":"CAPTURED",
+      "amount":{
+         "currency":"NOK",
+         "value":250
+      },
+      "timestamp":"2023-03-27T10:52:07.748Z",
+      "idempotencyKey":"19986263-dedf-4b8e-a424-8d042eee4013",
+      "success":true
+   },
+   {
+      "reference":"UNIQUE-PAYMENT-REFERENCE",
+      "pspReference":"2019200034",
+      "name":"CANCELLED",
+      "amount":{
+         "currency":"NOK",
+         "value":750
+      },
+      "timestamp":"2023-03-27T10:52:15.616Z",
+      "success":true
+   }
 ]
 ```
 

--- a/operations/get_info.md
+++ b/operations/get_info.md
@@ -48,7 +48,7 @@ An example response would look like this:
 ```
 
 In the case where the merchant requested `scopes` in the
-[`POST:/epayment/v1/payments`][create-payment-endpoint]
+[`POST:/payments`][create-payment-endpoint]
 request, the `profile` object will contain a `sub` identifying the customer,
 after the customer has authorized the payment,
 
@@ -62,6 +62,10 @@ For example (truncated):
   }
 }
 ```
+
+The `sub` can then be used to retrieve the user's info with the
+[Userinfo API](https://developer.vippsmobilepay.com/docs/APIs/userinfo-api):
+[`GET:i/userinfo/{sub}`](https://developer.vippsmobilepay.com/api/userinfo#operation/getUserinfo).
 
 [get-payment-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/epayment#tag/QueryPayments/operation/getPayment
 [create-payment-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/epayment#tag/CreatePayments/operation/createPayment

--- a/operations/get_info.md
+++ b/operations/get_info.md
@@ -7,65 +7,61 @@ END_METADATA -->
 
 # Get payment
 
-A [Get payment][get-payment-endpoint] request will return a point in time snapshot of a given payment.
-
-An example request would look like:
-
-```bash
-curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE \
--H "Authorization: Bearer <TOKEN>" \
--H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
--H "Merchant-Serial-Number: YOUR-MERCHANT-ACCOUNT-NUMBER" \
--X GET \
-'
-```
+A [`GET:/payments/{reference}`][get-payment-endpoint]
+request will return a point in time snapshot of a given payment.
 
 An example response would look like this:
 ```json
 {
-    "aggregate": {
-        "authorizedAmount": {
-            "currency": "NOK",
-            "value": 1000
-        },
-        "cancelledAmount": {
-            "currency": "NOK",
-            "value": 1000
-        },
-        "capturedAmount": {
-            "currency": "NOK",
-            "value": 0
-        },
-        "refundedAmount": {
-            "currency": "NOK",
-            "value": 0
-        }
-    },
-    "amount": {
-        "currency": "NOK",
-        "value": 1000
-    },
-    "state": "AUTHORIZED",
-    "paymentMethod": {
-        "type": "WALLET"
-    },
-    "profile": {},
-    "pspReference": "37c34d8c-2649-448e-864b-060d5d93e4c4",
-    "reference": "UNIQUE-PAYMENT-REFERENCE"
+   "aggregate":{
+      "authorizedAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "cancelledAmount":{
+         "currency":"NOK",
+         "value":1000
+      },
+      "capturedAmount":{
+         "currency":"NOK",
+         "value":0
+      },
+      "refundedAmount":{
+         "currency":"NOK",
+         "value":0
+      }
+   },
+   "amount":{
+      "currency":"NOK",
+      "value":1000
+   },
+   "state":"AUTHORIZED",
+   "paymentMethod":{
+      "type":"WALLET"
+   },
+   "profile":{
+
+   },
+   "pspReference":"37c34d8c-2649-448e-864b-060d5d93e4c4",
+   "reference":"UNIQUE-PAYMENT-REFERENCE"
 }
 ```
 
-In the case where the merchant requested `scopes` in the [Create payment][create-payment-endpoint] request, the `.profile` object will contain a `sub` identifying the customer, after the customer has authorized the payment, for example
+In the case where the merchant requested `scopes` in the
+[`POST:/epayment/v1/payments`][create-payment-endpoint]
+request, the `profile` object will contain a `sub` identifying the customer,
+after the customer has authorized the payment,
+
+For example (truncated):
+
 ```json
 {
-  ..., 
   "state": "AUTHORIZED",
   "profile" : {
     "sub": "c06c4afe-d9e1-4c5d-939a-177d752a0944"
   }
 }
 ```
-
 
 [get-payment-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/epayment#tag/QueryPayments/operation/getPayment
 [create-payment-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/epayment#tag/CreatePayments/operation/createPayment

--- a/operations/refund.md
+++ b/operations/refund.md
@@ -44,8 +44,6 @@ curl https://apitest.vipps.no/epayment/v1/payments/UNIQUE-PAYMENT-REFERENCE/refu
 }'
 ```
 
-
-
 In the response, the `aggregate` object will be updated to reflect the refunded amount, for example:
 
 ```json

--- a/payment_states.md
+++ b/payment_states.md
@@ -18,11 +18,8 @@ _modification_ is made.
 | ------------- | ------------- |
 | `CREATED`     | The payment has been initiated. |
 | `AUTHORIZED`  | The user has accepted the payment. |
-| `CAPTURED`    | The payment has been captured. |
-| `REFUNDED`    | The payment has been refunded. |
 | `ABORTED`     | The payment has been actively stopped by the user. |
 | `EXPIRED`     | The payment has expired. See [Timeouts](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/timeouts).|
-| `CANCELLED`   | The payment has been cancelled by the merchant. |
 | `TERMINATED`  | The merchant has stopped the payment. |
 
 When a payment is initiated it has the state `CREATED`.

--- a/payment_states.md
+++ b/payment_states.md
@@ -1,24 +1,38 @@
 <!-- START_METADATA
 ---
-title: Payment session states for ePayment
+title: Payment states and modifications
 sidebar_label: Payment states
 sidebar_position: 15
-description: Payment session states for ePayment.
+description: Payment states and modifications
 pagination_next: null
 pagination_prev: null
 ---
 END_METADATA -->
 
-# Payment session states
+# Payment states and modifications
 
-Once a payment is `CREATED`, several modification actions can be made.
-These are:
+A payment can have several different _states_, and change states when a
+_modification_ is made.
+
+| State         | Description   |
+| ------------- | ------------- |
+| `CREATED`     | The payment has been initiated. |
+| `AUTHORIZED`  | The user has accepted the payment. |
+| `CAPTURED`    | The payment has been captured. |
+| `REFUNDED`    | The payment has been refunded. |
+| `ABORTED`     | The payment has been actively stopped by the user. |
+| `EXPIRED`     | The payment has expired. See [Timeouts](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/timeouts).|
+| `CANCELLED`   | The payment has been cancelled by the merchant. |
+| `TERMINATED`  | The merchant has stopped the payment. |
+
+When a payment is initiated it has the state `CREATED`.
+Once a payment is `CREATED`, several modification actions can be made:
 
 - [Capture](./operations/capture.md)
 - [Refund](./operations/refund.md)
 - [Cancel](./operations/cancel.md)
 
-Modification actions are defined as separate endpoints in the api.
+Each modification action is defined as a separate endpoint in the API.
 
 The following flow diagram describes when each modification action is applicable.
 
@@ -50,7 +64,7 @@ REFUNDED : REFUNDED
 REFUNDED : Payment fully or partially refunded\nDefined by ""aggregate.refundedAmount"" object
 REFUNDED --> [*] : Once payment is\nfully refunded
 CREATED --> CANCELLED : Not possible if the user is \nactively authorizing the \npayment
-AUTHORIZED --> CANCELLED 
+AUTHORIZED --> CANCELLED
 CAPTURED --> CANCELLED : Not possible after \nfull capture
 CANCELLED : CANCELLED
 CANCELLED : Cancel the remaining un-captured amount\nDefined by ""aggregate.cancelledAmount"" object


### PR DESCRIPTION
Some suggested improvements. I've tried to make each commit concrete and understandable.

- Changed endpoint links to ``POST:/payments/{reference}/cancel`` (not "Cancel endpoint"). The link to the API spec Is unchanged.
- Changed curl examples to pure HTTP. We ask everyone to send the Vipps HTTP headers, and each example gets very long with all headers everywhere. And users have to edit 4-5 parameters anyway. A link to the API spec and an example of the request body is enough - IMHO.
- Removed curl examples that had no body, since the endpoint link is enough.